### PR TITLE
Update type declarations syntax to Crystal 0.12.x 

### DIFF
--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -64,7 +64,7 @@ create_double "Yet::Another::Namespaced" do
 end
 
 class SimpleWrapper(T)
-  @value :: T
+  @value : T
   def initialize(@value : T)
   end
 

--- a/src/mocks/allow.cr
+++ b/src/mocks/allow.cr
@@ -7,7 +7,7 @@ module Mocks
       subject
     end
 
-    @subject :: T
+    @subject : T
     getter subject
     def initialize(@subject : T)
     end

--- a/src/mocks/message.cr
+++ b/src/mocks/message.cr
@@ -2,8 +2,8 @@ require "./receive"
 
 module Mocks
   class Message(T, V)
-    @receive :: Receive(T)
-    @value :: V
+    @receive : Receive(T)
+    @value : V
 
     getter receive
     getter value

--- a/src/mocks/receive.cr
+++ b/src/mocks/receive.cr
@@ -2,8 +2,8 @@ require "./registry"
 
 module Mocks
   class Receive(T)
-    @args :: T
-    @method_name :: String
+    @args : T
+    @method_name : String
     getter args, method_name
 
     def initialize(@method_name, @args : T)

--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -8,7 +8,7 @@ module Mocks
     class ResultWrapper(T)
       include ResultInterface
 
-      @result :: T
+      @result : T
       getter result
       def initialize(@result : T)
       end
@@ -27,7 +27,7 @@ module Mocks
         new(object.object_id)
       end
 
-      @value :: String|UInt64
+      @value : String|UInt64
       def initialize(@value)
       end
 
@@ -51,7 +51,7 @@ module Mocks
     class Args(T)
       include ArgsInterface
 
-      @value :: T
+      @value : T
       getter value
 
       def initialize(@value : T)
@@ -75,8 +75,8 @@ module Mocks
     end
 
     class StubKey
-      @id :: ObjectId
-      @args :: ArgsInterface
+      @id : ObjectId
+      @args : ArgsInterface
       getter id, args
       def initialize(@id, @args)
       end
@@ -92,7 +92,7 @@ module Mocks
     end
 
     class CallHash
-      @hash :: Hash(StubKey, ResultInterface)
+      @hash : Hash(StubKey, ResultInterface)
       getter hash
 
       def initialize
@@ -111,9 +111,9 @@ module Mocks
     end
 
     class Method
-      @stubs :: CallHash
-      @received :: CallHash
-      @last_args :: CallHash
+      @stubs : CallHash
+      @received : CallHash
+      @last_args : CallHash
       getter stubs, received, last_args
       def initialize
         @stubs = CallHash.new
@@ -166,8 +166,8 @@ module Mocks
       @@_instances = {} of String => self
     end
 
-    @methods :: Hash(String, Method)
-    @name :: String
+    @methods : Hash(String, Method)
+    @name : String
     getter methods
 
     def initialize(@name)
@@ -181,8 +181,8 @@ module Mocks
     end
 
     class Result(T)
-      @call_original :: Bool
-      @value :: T
+      @call_original : Bool
+      @value : T
       getter call_original, value
 
       def initialize(@call_original, @value : T)


### PR DESCRIPTION
Since 0.12.x Crystal is supporting only a single `:` for type declarations

More info: 

manastech/crystal@2367653
http://crystal-lang.org/docs/syntax_and_semantics/instance_variables_type_inference.html
