### PR TITLE
Type clean rewrite

### DIFF
--- a/spec/mocks/registry_spec.cr
+++ b/spec/mocks/registry_spec.cr
@@ -1,64 +1,80 @@
 require "../spec_helper"
 
+macro method_for(name, method_name, args)
+  Registry(typeof({{args}}))
+    .for({{name}})
+    .fetch_method({{method_name}})
+end
+
 module Mocks
   class Registry
     describe Method do
       describe "#received?(object_id, args)" do
         it "is false when there were no such call" do
-          m = Registry.for("example class").fetch_method("say")
           oid = ObjectId.new(375_u64)
 
-          m.received?(oid).should eq(false)
-          m.received?(oid, ["hello world"]).should eq(false)
+          method_for("Example", "say", nil).received?(oid, nil)
+            .should eq(false)
+
+          method_for("Example", "say", {"hello world"}).received?(oid, {"hello world"})
+            .should eq(false)
         end
 
         it "is true when there was such call" do
-          m = Registry.for("example class").fetch_method("say")
           oid = ObjectId.new(375_u64)
 
-          m.call(oid)
-          m.received?(oid).should eq(true)
+          m = method_for("Example", "say", nil)
+          m.call(oid, nil)
+          m.received?(oid, nil).should eq(true)
 
-          m.call(oid, ["hello world"])
-          m.received?(oid, ["hello world"]).should eq(true)
+          m = method_for("Example", "say", {"hello world"})
+          m.call(oid, {"hello world"})
+          m.received?(oid, {"hello world"}).should eq(true)
         end
 
         it "is false when arguments are different" do
-          m = Registry.for("example class").fetch_method("say")
           oid = ObjectId.new(983_u64)
+          m = method_for("Example", "say", {"hello world"})
 
-          m.call(oid, ["hello test"])
-          m.received?(oid, ["hello world"]).should eq(false)
+          m.call(oid, {"hello test"})
+          m.received?(oid, {"hello test"}).should eq(true)
+          m.received?(oid, {"hello world"}).should eq(false)
         end
       end
 
       describe "#last_received_args(object_id)" do
         it "returns nil when there were no call" do
-          m = Registry.for("example class").fetch_method("say")
+          m = method_for("Example", "say", {"hello"})
           oid = ObjectId.new(983_u64)
           m.last_received_args(oid).should eq(nil)
         end
 
         it "returns arguments of last call" do
-          m = Registry.for("example class").fetch_method("say")
+          m_nil = method_for("Example", "say", nil)
+          m_str = method_for("Example", "say", {"test"})
           oid1 = ObjectId.new(983_u64)
           oid2 = ObjectId.new(777_u64)
 
-          m.call(oid1)
-          m.last_received_args(oid1).should eq(NoArgs.new)
+          m_nil.call(oid1, nil)
+          m_nil.last_received_args(oid1).should eq("[]")
+          m_str.last_received_args(oid1).should eq("[]")
 
-          m.call(oid1, ["hello world"])
-          m.call(oid1)
-          m.last_received_args(oid1).should eq(NoArgs.new)
+          m_str.call(oid1, {"hello world"})
+          m_nil.call(oid1, nil)
+          m_str.last_received_args(oid1).should eq("[]")
+          m_nil.last_received_args(oid1).should eq("[]")
 
-          m.call(oid2, ["hello world"])
-          m.call(oid2, ["hello test"])
-          m.last_received_args(oid1).should eq(NoArgs.new)
+          m_str.call(oid2, {"hello world"})
+          m_str.call(oid2, {"hello test"})
+          m_str.last_received_args(oid1).should eq("[]")
+          m_nil.last_received_args(oid1).should eq("[]")
 
-          m.last_received_args(oid2).should eq(["hello test"])
+          m_str.last_received_args(oid2).should eq(["hello test"].inspect)
+          m_nil.last_received_args(oid2).should eq(["hello test"].inspect)
 
-          m.call(oid1, ["hello world"])
-          m.last_received_args(oid1).should eq(["hello world"])
+          m_str.call(oid1, {"hello world"})
+          m_nil.last_received_args(oid1).should eq(["hello world"].inspect)
+          m_str.last_received_args(oid1).should eq(["hello world"].inspect)
         end
       end
     end

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -207,7 +207,7 @@ describe Mocks do
       a.should_not eq(59)
     end
 
-    it "works when wrapped in simple object" do
+    pending "works when wrapped in simple object" do
       a = Mocks.double("EqualityEdgeCase")
       b = Mocks.double("EqualityEdgeCase")
       c = Mocks.double("EqualityEdgeCase")
@@ -217,7 +217,7 @@ describe Mocks do
       SimpleWrapper.new(a).should eq(SimpleWrapper.new(c))
     end
 
-    it "allows to override default #== gracefully" do
+    pending "allows to override default #== gracefully" do
       a = Mocks.double("EqualityEdgeCase")
       b = Mocks.double("EqualityEdgeCase")
       allow(a).to receive(instance.==(b)).and_return(true)

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -207,7 +207,7 @@ describe Mocks do
       a.should_not eq(59)
     end
 
-    pending "works when wrapped in simple object" do
+    it "works when wrapped in simple object" do
       a = Mocks.double("EqualityEdgeCase")
       b = Mocks.double("EqualityEdgeCase")
       c = Mocks.double("EqualityEdgeCase")
@@ -217,7 +217,7 @@ describe Mocks do
       SimpleWrapper.new(a).should eq(SimpleWrapper.new(c))
     end
 
-    pending "allows to override default #== gracefully" do
+    it "allows to override default #== gracefully" do
       a = Mocks.double("EqualityEdgeCase")
       b = Mocks.double("EqualityEdgeCase")
       allow(a).to receive(instance.==(b)).and_return(true)

--- a/src/macro/base_double.cr
+++ b/src/macro/base_double.cr
@@ -9,9 +9,9 @@ module Mocks
         {% method_name = method_name.id %}
 
         {% if method.receiver.stringify == "self" %}
-             {% return_type = "typeof(typeof(#{sample}).#{method.name}(#{method.args.argify}))" %}
+          {% return_type = "typeof(typeof(#{sample}).#{method.name}(#{method.args.argify}))" %}
         {% else %}
-             {% return_type = "typeof(#{sample}.#{method.name}(#{method.args.argify}))".id %}
+          {% return_type = "typeof(#{sample}.#{method.name}(#{method.args.argify}))".id %}
         {% end %}
       {% else %}
 
@@ -32,13 +32,19 @@ module Mocks
       {% end %}
 
       def {{method_name}}({{method.args.argify}})
-        %method = ::Mocks::Registry.for(@@name).fetch_method("{{method_name}}")
-
         {% if method.args.empty? %}
-          %result = %method.call(::Mocks::Registry::ObjectId.build(self))
+          {% args_tuple = "nil".id %}
         {% else %}
-          %result = %method.call(::Mocks::Registry::ObjectId.build(self), [{{method.args.argify}}])
+          {% args_tuple = "{#{method.args.argify}}".id %}
         {% end %}
+
+        {% args_types = "typeof(#{args_tuple})".id %}
+
+        ::Mocks::Registry.remember({{args_types}})
+
+        %method = ::Mocks::Registry({{args_types}}).for(@@name).fetch_method("{{method_name}}")
+
+        %result = %method.call(::Mocks::Registry::ObjectId.build(self), {{args_tuple}})
 
         if %result.call_original
 

--- a/src/macro/base_mock.cr
+++ b/src/macro/base_mock.cr
@@ -25,12 +25,18 @@ module Mocks
           raise "Assertion failed (mocks.cr): @@__mocks_name can not be nil"
         end
 
-        %method = ::Mocks::Registry.for(%mock_name).fetch_method({{method_name.stringify}})
         {% if method.args.empty? %}
-          %result = %method.call(::Mocks::Registry::ObjectId.build(self))
+          {% args_tuple = "nil".id %}
         {% else %}
-          %result = %method.call(::Mocks::Registry::ObjectId.build(self), {{method.args}})
+          {% args_tuple = "{#{method.args.argify}}".id %}
         {% end %}
+
+        {% args_types = "typeof(#{args_tuple})".id %}
+
+        ::Mocks::Registry.remember({{args_types}})
+
+        %method = ::Mocks::Registry({{args_types}}).for(%mock_name).fetch_method({{method_name.stringify}})
+        %result = %method.call(::Mocks::Registry::ObjectId.build(self), {{args_tuple}})
 
         if %result.call_original
           {{previous}}

--- a/src/macro/etc.cr
+++ b/src/macro/etc.cr
@@ -7,9 +7,11 @@ module Mocks
         {% method_name = method_name.id %}
 
         {% if method.args.empty? %}
-          ::Mocks::Receive.new("{{method_name}}", ::Mocks::Registry::NoArgs.new)
+          ::Mocks::Receive(Nil).new("{{method_name}}", nil)
         {% else %}
-          ::Mocks::Receive.new("{{method_name}}", {{method.args}})
+          {% args_tuple = "{#{method.args.argify}}".id %}
+          {% args_types = "typeof(#{args_tuple})".id %}
+          ::Mocks::Receive({{args_types}}).new("{{method_name}}", {{args_tuple}})
         {% end %}
       end
 

--- a/src/mocks.cr
+++ b/src/mocks.cr
@@ -12,7 +12,7 @@ module Mocks
   end
 
   def reset
-    Registry.reset!
+    reset_registries
   end
 
   class UnexpectedMethodCall < Exception; end

--- a/src/mocks/allow.cr
+++ b/src/mocks/allow.cr
@@ -13,7 +13,8 @@ module Mocks
     end
 
     def to(message)
-      Mocks::Registry
+      message
+        .registry_for_its_args
         .for(subject_name)
         .fetch_method(message.method_name)
         .store_stub(object_id, message.args, message.value)

--- a/src/mocks/have_received_expectation.cr
+++ b/src/mocks/have_received_expectation.cr
@@ -11,8 +11,16 @@ module Mocks
       "expected: #{expected}\n     got: #{got}"
     end
 
+    def failure_message(_ignored)
+      failure_message
+    end
+
     def negative_failure_message
       "expected: receive != #{expected}\n     got: #{got}"
+    end
+
+    def negative_failure_message(_ignored)
+      negative_failure_message
     end
 
     private def method

--- a/src/mocks/have_received_expectation.cr
+++ b/src/mocks/have_received_expectation.cr
@@ -24,7 +24,8 @@ module Mocks
     end
 
     private def method
-      Registry
+      @receive
+        .registry_for_its_args
         .for(target_class_name(@target))
         .fetch_method(@receive.method_name)
     end
@@ -44,14 +45,18 @@ module Mocks
 
     private def got
       if args = last_args
-        return "#{@receive.method_name}#{args.inspect}"
+        return "#{@receive.method_name}#{args}"
       end
 
       "nil"
     end
 
     def expected
-      "#{@receive.method_name}#{@receive.args.inspect}"
+      "#{@receive.method_name}#{expected_args}"
+    end
+
+    def expected_args
+      @receive.args ? @receive.args.to_a.inspect : "[]"
     end
 
     private def last_args

--- a/src/mocks/message.cr
+++ b/src/mocks/message.cr
@@ -18,5 +18,9 @@ module Mocks
     def args
       receive.args
     end
+
+    def registry_for_its_args
+      receive.registry_for_its_args
+    end
   end
 end

--- a/src/mocks/receive.cr
+++ b/src/mocks/receive.cr
@@ -12,5 +12,9 @@ module Mocks
     def and_return(value)
       Message.new(self, value)
     end
+
+    def registry_for_its_args
+      Registry(T)
+    end
   end
 end


### PR DESCRIPTION
This PR upgrades `mocks` to a newer version of Crystal.

Additionally it gets rid of union types in argument list handling, therefore, Crystal's type system will not be confused, as it was here: crystal-lang/crystal#2376
