### PR TITLE
Fix Arithmetic overflow (OverflowError) for Crystal 0.31.1

### DIFF
--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -83,7 +83,7 @@ module Mocks
       end
 
       def hash
-        object_id.hash * 32 + args.hash
+        object_id.hash &* 32 &+ args.hash
       end
 
       def inspect(io)
@@ -122,7 +122,7 @@ module Mocks
       end
 
       def hash
-        @registry_name.hash * 32 * 32 + @name.hash * 32 + @object_id.hash
+        @registry_name.hash &* 32 &* 32 &+ @name.hash &* 32 &+ @object_id.hash
       end
 
       def inspect(io)


### PR DESCRIPTION
All of the specs were failing with an Arithmetic overflow (OverflowError) in the hash calculations, and I also got this crash when I was trying out the mocks.cr library. See: #38

I think this might be because overflows were previously ignored, but Crystal has started crashing with an OverflowError in this case. My change just does some bit shifts to make sure that adding multiple hashes will never overflow a `UInt64`.

I also [posted on the Crystal forums](https://forum.crystal-lang.org/t/is-there-any-way-to-explicitly-allow-arithmetic-overflow-for-hash-calculations/1449) to see if there might be a way to ignore the overflow error.
