### PR TITLE
Added a failing test to show that mocking File.read_lines is currently broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Mocks.create_struct_mock Example do
 end
 
 example = Example.new
-allow(example).to receive(now).and_return(Time.new(2014, 12, 22))
+allow(example).to receive(now).and_return(Time.local(2014, 12, 22))
 ```
 
 ### Double

--- a/spec/mocks/create_module_mock_spec.cr
+++ b/spec/mocks/create_module_mock_spec.cr
@@ -10,8 +10,8 @@ Mocks.create_module_mock MyModule do
   mock self.exists?(name)
 end
 
-Mocks.create_mock File do
-  mock self.exists?(name)
+Mocks.create_module_mock Crystal::System::File do
+  mock self.exists?(path)
 end
 
 describe "create module mock macro" do
@@ -22,7 +22,7 @@ describe "create module mock macro" do
   end
 
   it "does not fail with Nil errors for stdlib class" do
-    allow(File).to receive(self.exists?("hello")).and_return(true)
+    allow(Crystal::System::File).to receive(self.exists?("hello")).and_return(true)
     File.exists?("world").should eq(false)
     File.exists?("hello").should eq(true)
   end

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -59,6 +59,10 @@ Mocks.create_mock AnotherExample do
   mock self.hello_world
 end
 
+Mocks.create_mock File do
+  mock self.read_lines(filename, encoding = nil, invalid = nil, chomp = true)
+end
+
 Mocks.create_module_mock ModuleExample do
   mock self.hello_world
 end
@@ -137,6 +141,11 @@ describe Mocks do
 
       allow(Example).to receive(self.hello_world("halo")).and_return("halo there world")
       Example.hello_world("halo").should eq("halo there world")
+    end
+
+    it "mocks File.read_lines" do
+      allow(File).to receive(self.read_lines("example")).and_return(["hey, world!\n"])
+      File.read_lines("example").should eq(["hey, world!\n"])
     end
 
     it "works with module methods" do

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -42,7 +42,7 @@ end
 
 struct StructTimeExample
   def self.now
-    Time.new(2015, 1, 10)
+    Time.local(2015, 1, 10)
   end
 end
 
@@ -147,10 +147,10 @@ describe Mocks do
     end
 
     it "works with struct methods" do
-      StructTimeExample.now.should eq(Time.new(2015, 1, 10))
+      StructTimeExample.now.should eq(Time.local(2015, 1, 10))
 
-      allow(StructTimeExample).to receive(self.now).and_return(Time.new(2014, 12, 22))
-      StructTimeExample.now.should eq(Time.new(2014, 12, 22))
+      allow(StructTimeExample).to receive(self.now).and_return(Time.local(2014, 12, 22))
+      StructTimeExample.now.should eq(Time.local(2014, 12, 22))
     end
 
     it "affects only the same class" do

--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -83,7 +83,7 @@ module Mocks
       end
 
       def hash
-        object_id.hash * 32 + args.hash
+        object_id.hash &* 32 &+ args.hash
       end
 
       def inspect(io)
@@ -122,7 +122,7 @@ module Mocks
       end
 
       def hash
-        @registry_name.hash * 32 * 32 + @name.hash * 32 + @object_id.hash
+        @registry_name.hash &* 32 &* 32 &+ @name.hash &* 32 &+ @object_id.hash
       end
 
       def inspect(io)


### PR DESCRIPTION
This PR includes #40, which fixes most of the tests that were crashing on Crystal 0.31.1

This related spec is still failing: https://github.com/waterlink/mocks.cr/issues/37

So I think I'm running into the same issue with this case.

See also: https://github.com/waterlink/mocks.cr/issues/38