### PR TITLE
Fix time deprecations (Warning: Deprecated Time.new. Use Time.local instead.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Mocks.create_struct_mock Example do
 end
 
 example = Example.new
-allow(example).to receive(now).and_return(Time.new(2014, 12, 22))
+allow(example).to receive(now).and_return(Time.local(2014, 12, 22))
 ```
 
 ### Double

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -42,7 +42,7 @@ end
 
 struct StructTimeExample
   def self.now
-    Time.new(2015, 1, 10)
+    Time.local(2015, 1, 10)
   end
 end
 
@@ -147,10 +147,10 @@ describe Mocks do
     end
 
     it "works with struct methods" do
-      StructTimeExample.now.should eq(Time.new(2015, 1, 10))
+      StructTimeExample.now.should eq(Time.local(2015, 1, 10))
 
-      allow(StructTimeExample).to receive(self.now).and_return(Time.new(2014, 12, 22))
-      StructTimeExample.now.should eq(Time.new(2014, 12, 22))
+      allow(StructTimeExample).to receive(self.now).and_return(Time.local(2014, 12, 22))
+      StructTimeExample.now.should eq(Time.local(2014, 12, 22))
     end
 
     it "affects only the same class" do

--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -83,7 +83,7 @@ module Mocks
       end
 
       def hash
-        object_id.hash * 32 + args.hash
+        (object_id.hash >> 2) + (args.hash >> 2)
       end
 
       def inspect(io)
@@ -122,7 +122,7 @@ module Mocks
       end
 
       def hash
-        @registry_name.hash * 32 * 32 + @name.hash * 32 + @object_id.hash
+        (@registry_name.hash >> 3) + (@name.hash >> 3) + (@object_id.hash >> 3)
       end
 
       def inspect(io)


### PR DESCRIPTION
`Time.new` is now deprecated, and we need to use `Time.local` instead. This PR includes #40 to fix most of the failing specs, and also fixes the following deprecation warnings:

```
In spec/mocks_spec.cr:45:10

 45 | Time.new(2015, 1, 10)
           ^--
Warning: Deprecated Time.new. Use `Time.local` instead.

In spec/mocks_spec.cr:150:44

 150 | StructTimeExample.now.should eq(Time.new(2015, 1, 10))
                                            ^--
Warning: Deprecated Time.new. Use `Time.local` instead.

In spec/mocks_spec.cr:152:69

 152 | allow(StructTimeExample).to receive(self.now).and_return(Time.new(2014, 12, 22))
                                                                     ^--
Warning: Deprecated Time.new. Use `Time.local` instead.

In spec/mocks_spec.cr:153:44

 153 | StructTimeExample.now.should eq(Time.new(2014, 12, 22))
                                            ^--
Warning: Deprecated Time.new. Use `Time.local` instead.

A total of 4 warnings were found.
```