### PR TITLE
Fix all specs and deprecation warnings for Crystal 0.31.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Mocks.create_struct_mock Example do
 end
 
 example = Example.new
-allow(example).to receive(now).and_return(Time.new(2014, 12, 22))
+allow(example).to receive(now).and_return(Time.local(2014, 12, 22))
 ```
 
 ### Double

--- a/spec/mocks/create_module_mock_spec.cr
+++ b/spec/mocks/create_module_mock_spec.cr
@@ -10,8 +10,8 @@ Mocks.create_module_mock MyModule do
   mock self.exists?(name)
 end
 
-Mocks.create_mock File do
-  mock self.exists?(name)
+Mocks.create_module_mock Crystal::System::File do
+  mock self.exists?(path)
 end
 
 describe "create module mock macro" do
@@ -22,7 +22,7 @@ describe "create module mock macro" do
   end
 
   it "does not fail with Nil errors for stdlib class" do
-    allow(File).to receive(self.exists?("hello")).and_return(true)
+    allow(Crystal::System::File).to receive(self.exists?("hello")).and_return(true)
     File.exists?("world").should eq(false)
     File.exists?("hello").should eq(true)
   end

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -42,7 +42,7 @@ end
 
 struct StructTimeExample
   def self.now
-    Time.new(2015, 1, 10)
+    Time.local(2015, 1, 10)
   end
 end
 
@@ -147,10 +147,10 @@ describe Mocks do
     end
 
     it "works with struct methods" do
-      StructTimeExample.now.should eq(Time.new(2015, 1, 10))
+      StructTimeExample.now.should eq(Time.local(2015, 1, 10))
 
-      allow(StructTimeExample).to receive(self.now).and_return(Time.new(2014, 12, 22))
-      StructTimeExample.now.should eq(Time.new(2014, 12, 22))
+      allow(StructTimeExample).to receive(self.now).and_return(Time.local(2014, 12, 22))
+      StructTimeExample.now.should eq(Time.local(2014, 12, 22))
     end
 
     it "affects only the same class" do

--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -83,7 +83,7 @@ module Mocks
       end
 
       def hash
-        object_id.hash * 32 + args.hash
+        object_id.hash &* 32 &+ args.hash
       end
 
       def inspect(io)
@@ -122,7 +122,7 @@ module Mocks
       end
 
       def hash
-        @registry_name.hash * 32 * 32 + @name.hash * 32 + @object_id.hash
+        @registry_name.hash &* 32 &* 32 &+ @name.hash &* 32 &+ @object_id.hash
       end
 
       def inspect(io)


### PR DESCRIPTION
I fixed all the specs and deprecation warnings for Crystal 0.31.1:

```
$ crystal spec
.......................................................

Finished in 3.85 milliseconds
55 examples, 0 failures, 0 errors, 0 pending
```

## Changes:

### Fix Arithmetic overflow (OverflowError) in the hash calculations

Crystal [added new "wrapping" arithmetic operators in `0.27.0`](https://crystal-lang.org/2018/11/01/crystal-0.27.0-released.html), and the hash calculations now raise an OverflowError unless these are used.

### Fix `Time.now` deprecation

[`Time.now` was deprecated in Crystal 0.28.0](https://crystal-lang.org/2019/04/17/crystal-0.28.0-released.html), and needs to be replaced with `Time.local`.

### Need to mock `Crystal::System::File.exists?` 

(Not sure when this changed, or if it's related to other changes in the Crystal language.)

* [file.cr](https://github.com/crystal-lang/crystal/blob/master/src/file.cr) requires:
  * [crystal/system/file](https://github.com/crystal-lang/crystal/blob/master/src/crystal/system/file.cr), which [requires](https://github.com/crystal-lang/crystal/blob/master/src/crystal/system/file.cr#L45-L51) either:
    * [crystal/system/unix/file.cr](https://github.com/crystal-lang/crystal/blob/master/src/crystal/system/unix/file.cr)
    * or [crystal/system/win32/file.cr](https://github.com/crystal-lang/crystal/blob/master/src/crystal/system/win32/file.cr)

So I updated the test to mock `Crystal::System::File`, which fixes the failing test. (But maybe this is just a temporary workaround.)

Original PRs:

* https://github.com/waterlink/mocks.cr/pull/40
* https://github.com/waterlink/mocks.cr/pull/42