### PR TITLE
Added failing test for default values in arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Mocks.create_struct_mock Example do
 end
 
 example = Example.new
-allow(example).to receive(now).and_return(Time.new(2014, 12, 22))
+allow(example).to receive(now).and_return(Time.local(2014, 12, 22))
 ```
 
 ### Double

--- a/spec/mocks/create_module_mock_spec.cr
+++ b/spec/mocks/create_module_mock_spec.cr
@@ -10,8 +10,8 @@ Mocks.create_module_mock MyModule do
   mock self.exists?(name)
 end
 
-Mocks.create_mock File do
-  mock self.exists?(name)
+Mocks.create_module_mock Crystal::System::File do
+  mock self.exists?(path)
 end
 
 describe "create module mock macro" do
@@ -22,7 +22,7 @@ describe "create module mock macro" do
   end
 
   it "does not fail with Nil errors for stdlib class" do
-    allow(File).to receive(self.exists?("hello")).and_return(true)
+    allow(Crystal::System::File).to receive(self.exists?("hello")).and_return(true)
     File.exists?("world").should eq(false)
     File.exists?("hello").should eq(true)
   end

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -9,6 +9,10 @@ class Example
     "#{greeting} world"
   end
 
+  def self.hello_world_default(greeting, object = "world")
+    "#{greeting} to the #{object}"
+  end
+
   def say_hello
     "hey!"
   end
@@ -49,6 +53,7 @@ end
 Mocks.create_mock Example do
   mock self.hello_world
   mock self.hello_world(greeting)
+  mock self.hello_world_default(greeting, object = "world")
   mock instance.say_hello
   mock instance.say_hello(name)
   mock instance.greeting = value
@@ -137,6 +142,13 @@ describe Mocks do
 
       allow(Example).to receive(self.hello_world("halo")).and_return("halo there world")
       Example.hello_world("halo").should eq("halo there world")
+    end
+
+    it "works with class methods that have default values for arguments" do
+      Example.hello_world_default("hello").should eq("hello to the world")
+
+      allow(Example).to receive(self.hello_world_default("halo", "earth")).and_return("halo there earth")
+      Example.hello_world_default("halo", "earth").should eq("halo there earth")
     end
 
     it "works with module methods" do

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -42,7 +42,7 @@ end
 
 struct StructTimeExample
   def self.now
-    Time.new(2015, 1, 10)
+    Time.local(2015, 1, 10)
   end
 end
 
@@ -147,10 +147,10 @@ describe Mocks do
     end
 
     it "works with struct methods" do
-      StructTimeExample.now.should eq(Time.new(2015, 1, 10))
+      StructTimeExample.now.should eq(Time.local(2015, 1, 10))
 
-      allow(StructTimeExample).to receive(self.now).and_return(Time.new(2014, 12, 22))
-      StructTimeExample.now.should eq(Time.new(2014, 12, 22))
+      allow(StructTimeExample).to receive(self.now).and_return(Time.local(2014, 12, 22))
+      StructTimeExample.now.should eq(Time.local(2014, 12, 22))
     end
 
     it "affects only the same class" do

--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -83,7 +83,7 @@ module Mocks
       end
 
       def hash
-        object_id.hash * 32 + args.hash
+        object_id.hash &* 32 &+ args.hash
       end
 
       def inspect(io)
@@ -122,7 +122,7 @@ module Mocks
       end
 
       def hash
-        @registry_name.hash * 32 * 32 + @name.hash * 32 + @object_id.hash
+        @registry_name.hash &* 32 &* 32 &+ @name.hash &* 32 &+ @object_id.hash
       end
 
       def inspect(io)


### PR DESCRIPTION
* Depends on: #43 
* Related to: #41

I realized that `mocks.cr` doesn't actually support mocking any methods that have [default values for arguments](https://crystal-lang.org/reference/syntax_and_semantics/default_and_named_arguments.html#default-values), so I am unable to mock `File.read_lines` because it has some default values.

I've added some failing specs to ensure that a method with default values can be mocked. 