### PR TITLE
Compatibility fixes for 0.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Mocks.create_struct_mock Example do
 end
 
 example = Example.new
-allow(example).to receive(now).and_return(Time.new(2014, 12, 22))
+allow(example).to receive(now).and_return(Time.utc(2014, 12, 22))
 ```
 
 ### Double

--- a/spec/mocks/create_module_mock_spec.cr
+++ b/spec/mocks/create_module_mock_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 module MyModule
   def self.exists?(name)
-    false
+    "an unchanged value"
   end
 end
 
@@ -14,16 +14,28 @@ Mocks.create_mock File do
   mock self.exists?(name)
 end
 
-describe "create module mock macro" do
-  it "does not fail with Nil errors" do
-    allow(MyModule).to receive(self.exists?("hello")).and_return(true)
-    MyModule.exists?("world").should eq(false)
-    MyModule.exists?("hello").should eq(true)
+describe "::allow Macro" do
+  context "When mocking a method on a custom class" do
+    before_each do
+      allow(MyModule).to receive(self.exists?("hello")).and_return("the changed value")
+    end
+    it "responds with changed value for a mocked signature" do
+      MyModule.exists?("hello").should eq("the changed value")
+    end
+    it "responds with unchanged value for an unmocked signature" do
+      MyModule.exists?("world").should eq("an unchanged value")
+    end
   end
+  context "When mocking a method on a stdlib class" do
+    before_each do
+      allow(File).to receive(self.exists?("hello")).and_return(true)
+    end
 
-  it "does not fail with Nil errors for stdlib class" do
-    allow(File).to receive(self.exists?("hello")).and_return(true)
-    File.exists?("world").should eq(false)
-    File.exists?("hello").should eq(true)
+    it "responds with changed value for a mocked signature" do
+      File.exists?("hello").should eq(true)
+    end
+    it "responds with unchanged value for an unmocked signature" do
+      File.exists?("world").should eq(false)
+    end
   end
 end

--- a/spec/mocks_spec.cr
+++ b/spec/mocks_spec.cr
@@ -42,7 +42,7 @@ end
 
 struct StructTimeExample
   def self.now
-    Time.new(2015, 1, 10)
+    Time.utc(2015, 1, 10)
   end
 end
 
@@ -147,10 +147,10 @@ describe Mocks do
     end
 
     it "works with struct methods" do
-      StructTimeExample.now.should eq(Time.new(2015, 1, 10))
+      StructTimeExample.now.should eq(Time.utc(2015, 1, 10))
 
-      allow(StructTimeExample).to receive(self.now).and_return(Time.new(2014, 12, 22))
-      StructTimeExample.now.should eq(Time.new(2014, 12, 22))
+      allow(StructTimeExample).to receive(self.now).and_return(Time.utc(2014, 12, 22))
+      StructTimeExample.now.should eq(Time.utc(2014, 12, 22))
     end
 
     it "affects only the same class" do

--- a/src/mocks/registry.cr
+++ b/src/mocks/registry.cr
@@ -1,7 +1,15 @@
 require "singleton"
+require "big"
 
 module Mocks
   REGISTRIES = [] of Registry.class
+
+  def self.multi_hash(first : UInt64, *hashes)
+    return BigInt.new(first) if hashes.size < 1
+    hashes.reduce(BigInt.new(first)) { |acc, i|
+        (acc << 64) + BigInt.new(i) 
+    }
+  end
 
   def self.reset_registries
     Singleton.reset
@@ -72,7 +80,7 @@ module Mocks
     class CallHashKey(T)
       @object_id : ObjectId
       @args : T
-      protected getter object_id
+      getter object_id
       protected getter args
       def initialize(@object_id, @args)
       end
@@ -83,7 +91,7 @@ module Mocks
       end
 
       def hash
-        object_id.hash * 32 + args.hash
+        Mocks.multi_hash(object_id.hash, args.hash)
       end
 
       def inspect(io)
@@ -111,7 +119,7 @@ module Mocks
     class LastArgsKey
       protected getter registry_name
       protected getter name
-      protected getter object_id
+      getter object_id
       def initialize(@registry_name : String, @name : String, @object_id : ObjectId)
       end
 
@@ -122,7 +130,7 @@ module Mocks
       end
 
       def hash
-        @registry_name.hash * 32 * 32 + @name.hash * 32 + @object_id.hash
+        Mocks.multi_hash(@registry_name.hash, @name.hash, @object_id.hash)
       end
 
       def inspect(io)


### PR DESCRIPTION
* Time.new -> Time.utc
* object_id needed to be made public, since the new hash implementation
in 0.32 expects it to be available (presumably because of
compare_by_identity)?
* Used BigInt to deal with arithmetic overflow in hash methods - I hope
I got the spirit of what's being accomplished here correct - a bitmask'd
unique number.
* Changed multiplications 32*32 to bitwise shifts to make intent
clearer.

---
What I haven't solved yet is the (currently failing) test for overriding a builtin class (.e.g. File) - My current investigations indicate this is because you need to specify the argument and the argument restrictions exactly, otherwise the overload never gets called. 

See this example: 
https://play.crystal-lang.org/#/r/8vtj